### PR TITLE
Adding SortedList for completeness

### DIFF
--- a/Benchmarks/Tests/SortDictionary.cs
+++ b/Benchmarks/Tests/SortDictionary.cs
@@ -88,5 +88,30 @@ namespace Tests
             {
             }
         }
+        
+        [Benchmark]
+        public void SortedListAdd()
+        {
+            var list = new SortedList<string, string>(dictionary.Count, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kvp in dictionary)
+            {
+                list.Add(kvp.Key, kvp.Value);
+            }
+
+            foreach (var kvp in list)
+            {
+            }
+        }
+
+        [Benchmark]
+        public void SortedListConstructor()
+        {
+            var list = new SortedList<string, string>(dictionary, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var kvp in list)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
I was just curious how this would compare, and on my machine SortedList is faster, but allocates slightly more:

|                  Method |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------:|----------:|----------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|                 OrderBy | 7.374 us | 0.2716 us | 0.8007 us | 7.334 us |  1.00 |    0.00 | 0.0458 |     - |     - |     260 B |
|  SortInPlaceMethodGroup | 1.804 us | 0.0666 us | 0.1953 us | 1.803 us |  0.25 |    0.04 | 0.0267 |     - |     - |     144 B |
|       SortInPlaceLambda | 1.994 us | 0.1118 us | 0.3262 us | 1.976 us |  0.27 |    0.06 | 0.0191 |     - |     - |     112 B |
| SortInPlaceKeyValuePair | 1.835 us | 0.0717 us | 0.2113 us | 1.909 us |  0.25 |    0.04 | 0.0191 |     - |     - |     112 B |
|       SortedListWithAdd | 1.768 us | 0.0509 us | 0.1467 us | 1.753 us |  0.24 |    0.03 | 0.0305 |     - |     - |     160 B |
|   SortedListConstructor | 1.606 us | 0.0530 us | 0.1555 us | 1.633 us |  0.22 |    0.03 | 0.0305 |     - |     - |     160 B |