### PR TITLE
CopyTo dictionary benchmark

### DIFF
--- a/Benchmarks/Tests/SortDictionary.cs
+++ b/Benchmarks/Tests/SortDictionary.cs
@@ -88,5 +88,19 @@ namespace Tests
             {
             }
         }
+
+        [Benchmark]
+        public void SortInPlaceCopyToKeyValuePair()
+        {
+            var list = new KeyValuePair<string, string>[dictionary.Count];
+
+            ((ICollection<KeyValuePair<string, string>>)dictionary).CopyTo(list, 0);
+
+            Array.Sort(list, (l, r) => string.Compare(l.Key, r.Key, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var kvp in list)
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
Use CopyTo to get the items out of the Dictionary into an array and go straight to the `string.Compare` for the comparison.

|                        Method |       Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |-----------:|--------:|--------:|-------:|------:|------:|----------:|
|       SortInPlaceKeyValuePair | 1,198.7 ns | 1.26 ns | 1.05 ns | 0.0343 |     - |     - |     112 B |
| SortInPlaceCopyToKeyValuePair |   865.3 ns | 0.51 ns | 0.39 ns | 0.0277 |     - |     - |      88 B |