### PR TITLE
Added SortWhileProducing and Enumerable benchmarks.

### DIFF
--- a/Benchmarks/Tests/SortDictionary.cs
+++ b/Benchmarks/Tests/SortDictionary.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 
@@ -25,6 +26,24 @@ namespace Tests
         public void OrderBy()
         {
             var result = dictionary.OrderBy(kvp => kvp.Key);
+            foreach (var item in result)
+            {
+            }
+        }
+
+        [Benchmark]
+        public void SortedDictionary()
+        {
+            var result = new SortedDictionary<string, string>(dictionary);
+            foreach (var item in result)
+            {
+            }
+        }
+
+        [Benchmark]
+        public void SortedList()
+        {
+            var result = new SortedList<string, string>(dictionary);
             foreach (var item in result)
             {
             }
@@ -86,6 +105,111 @@ namespace Tests
 
             foreach (var kvp in list)
             {
+            }
+        }
+
+        [Benchmark]
+        public void SortWhileProducing()
+        {
+            var enumerator = dictionary.GetEnumerator();
+
+            if (enumerator.MoveNext())
+            {
+                var buffer = new KeyValuePair<string, string>[dictionary.Count - 1];
+                var smaller = enumerator.Current;
+
+                for (var i = 0; enumerator.MoveNext();)
+                {
+                    if (enumerator.Current.Key.CompareTo(smaller.Key) < 0)
+                    {
+                        buffer[i++] = smaller;
+                        smaller = enumerator.Current;
+                    }
+                    else
+                    {
+                        buffer[i++] = enumerator.Current;
+                    }
+                }
+
+                enumerator.Dispose();
+
+                // Debug.WriteLine(smaller.ToString());
+
+                for (var i = 0; i < buffer.Length - 1; i++)
+                {
+                    smaller = buffer[i];
+
+                    for (var j = i + 1; j < buffer.Length; j++)
+                    {
+                        var current = buffer[j];
+
+                        if (current.Key.CompareTo(smaller.Key) <= 0)
+                        {
+                            buffer[j] = smaller;
+                            smaller = current;
+                        }
+                    }
+
+                    // Debug.WriteLine(smaller.ToString());
+                }
+
+                // Debug.WriteLine(buffer[buffer.Length - 1].ToString());
+            }
+        }
+
+        [Benchmark]
+        public void Enumerable()
+        {
+            foreach (var kvp in GetEnumerator(dictionary))
+            {
+            }
+
+            IEnumerable<KeyValuePair<string, string>> GetEnumerator(Dictionary<string, string> dictionary)
+            {
+                var enumerator = dictionary.GetEnumerator();
+
+                if (enumerator.MoveNext())
+                {
+                    var buffer = new KeyValuePair<string, string>[dictionary.Count - 1];
+                    var smaller = enumerator.Current;
+
+                    for (var i = 0; enumerator.MoveNext();)
+                    {
+                        if (enumerator.Current.Key.CompareTo(smaller.Key) < 0)
+                        {
+                            buffer[i++] = smaller;
+                            smaller = enumerator.Current;
+                        }
+                        else
+                        {
+                            buffer[i++] = enumerator.Current;
+                        }
+                    }
+
+                    enumerator.Dispose();
+
+                    yield return smaller;
+
+                    for (var i = 0; i < buffer.Length - 1; i++)
+                    {
+                        smaller = buffer[i];
+
+                        for (var j = i + 1; j < buffer.Length; j++)
+                        {
+                            var current = buffer[j];
+
+                            if (current.Key.CompareTo(smaller.Key) <= 0)
+                            {
+                                buffer[j] = smaller;
+                                smaller = current;
+                            }
+                        }
+
+                        yield return smaller;
+                    }
+
+                    yield return buffer[buffer.Length - 1];
+                }
             }
         }
     }


### PR DESCRIPTION
|                  Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
|                 OrderBy | 7.400 us | 0.2620 us | 0.7391 us | 7.280 us | 0.0610 |     - |     - |     261 B |
|        SortedDictionary | 4.118 us | 0.1031 us | 0.2890 us | 4.095 us | 0.0916 |     - |     - |     389 B |
|              SortedList | 7.794 us | 0.1551 us | 0.3134 us | 7.715 us | 0.0381 |     - |     - |     160 B |
|  SortInPlaceMethodGroup | 2.214 us | 0.1152 us | 0.3379 us | 2.074 us | 0.0343 |     - |     - |     144 B |
|       SortInPlaceLambda | 2.282 us | 0.1273 us | 0.3693 us | 2.280 us | 0.0267 |     - |     - |     112 B |
| SortInPlaceKeyValuePair | 1.475 us | 0.0352 us | 0.0963 us | 1.443 us | 0.0267 |     - |     - |     112 B |
|      SortWhileProducing | 3.796 us | 0.1299 us | 0.3489 us | 3.673 us | 0.0153 |     - |     - |      68 B |
|              Enumerable | 3.924 us | 0.0772 us | 0.1224 us | 3.907 us | 0.0229 |     - |     - |     108 B |

There are still some time optimizations needed, but uses less memory.