### PR TITLE
Fix string comparison

### DIFF
--- a/Benchmarks/Tests/SortDictionary.cs
+++ b/Benchmarks/Tests/SortDictionary.cs
@@ -152,7 +152,7 @@ namespace Tests
 
                 for (var i = 0; enumerator.MoveNext();)
                 {
-                    if (enumerator.Current.Key.CompareTo(smaller.Key) < 0)
+                    if (string.Compare(enumerator.Current.Key, smaller.Key, StringComparison.OrdinalIgnoreCase) < 0)
                     {
                         buffer[i++] = smaller;
                         smaller = enumerator.Current;
@@ -175,7 +175,7 @@ namespace Tests
                     {
                         var current = buffer[j];
 
-                        if (current.Key.CompareTo(smaller.Key) <= 0)
+                        if (string.Compare(current.Key, smaller.Key, StringComparison.OrdinalIgnoreCase) <= 0)
                         {
                             buffer[j] = smaller;
                             smaller = current;
@@ -207,7 +207,7 @@ namespace Tests
 
                     for (var i = 0; enumerator.MoveNext();)
                     {
-                        if (enumerator.Current.Key.CompareTo(smaller.Key) < 0)
+                        if (string.Compare(enumerator.Current.Key, smaller.Key, StringComparison.OrdinalIgnoreCase) < 0)
                         {
                             buffer[i++] = smaller;
                             smaller = enumerator.Current;
@@ -230,7 +230,7 @@ namespace Tests
                         {
                             var current = buffer[j];
 
-                            if (current.Key.CompareTo(smaller.Key) <= 0)
+                            if (string.Compare(current.Key, smaller.Key, StringComparison.OrdinalIgnoreCase) <= 0)
                             {
                                 buffer[j] = smaller;
                                 smaller = current;


### PR DESCRIPTION
The comparer used was `string.CompareTo`. Changed to `string.Compare(string, string, StringComparison.OrdinalIgnoreCase)`which is what is invoked by `StringComparer.OrdinalIgnoreCase.Compare` (used by other tests).

|                  Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
|                 OrderBy | 13.802 us | 0.2763 us | 0.8060 us | 0.0610 |     - |     - |     261 B |
|        SortedDictionary |  8.400 us | 0.2128 us | 0.6207 us | 0.0916 |     - |     - |     389 B |
|              SortedList | 14.230 us | 0.2846 us | 0.8026 us | 0.0305 |     - |     - |     160 B |
|  SortInPlaceMethodGroup |  4.217 us | 0.0988 us | 0.2912 us | 0.0343 |     - |     - |     144 B |
|       SortInPlaceLambda |  4.284 us | 0.0749 us | 0.0700 us | 0.0229 |     - |     - |     112 B |
| SortInPlaceKeyValuePair |  4.155 us | 0.0884 us | 0.2606 us | 0.0229 |     - |     - |     112 B |
|      SortWhileProducing |  1.754 us | 0.0364 us | 0.1074 us | 0.0153 |     - |     - |      68 B |
|              Enumerable |  2.503 us | 0.0498 us | 0.1082 us | 0.0229 |     - |     - |     108 B |